### PR TITLE
fehler in Kapitel 7 behoben

### DIFF
--- a/chapters/chapter7.tex
+++ b/chapters/chapter7.tex
@@ -60,8 +60,8 @@
 			Fall 3: \(0<a<1\). Dann ist \(b := \frac{1}{a}>1\).
 			\[\overset{\text{Fall 2}}{\Rightarrow} \limes{n} b^{\frac{1}{n}} = 1\]
 			\begin{align*}
-				|a^{\nicefrac{1}{n}}-1|&=a^{\nicefrac{1}{n}}\left|1-\frac{a}{a^{\nicefrac{1}{n}}}\right|\\
-				&= a^{\nicefrac{1}{n}}\left| 1 - {\left(\frac{a}{a}\right)}^{\nicefrac{1}{n}} \right|\\
+				|a^{\nicefrac{1}{n}}-1|&=a^{\nicefrac{1}{n}}\left|1-\frac{1}{a^{\nicefrac{1}{n}}}\right|\\
+				&= a^{\nicefrac{1}{n}}\left| 1 - {\left(\frac{1}{a}\right)}^{\nicefrac{1}{n}} \right|\\
 				&= a^{\nicefrac{1}{n}} \left|1-b^{\nicefrac{1}{n}}\right|\\
 				&\leq \left|1-b^{\nicefrac{1}{n}} \right|\underset{n\rightarrow\infty}{\longrightarrow} 0
 			\end{align*}


### PR DESCRIPTION
Hallo !

Ich glaube einen kleinen Fehler in Beispiel 7.1.2.1 entdeckt zu haben. 
In Kapitel 7 in dem Beweis des 6. Beispiels im Fall 3 sollte über dem Bruch "1" anstatt "a".
  
Vielen Dank für das Skript !
 
Schönes Wochenende
Louis